### PR TITLE
Potential fix for code scanning alert no. 2: Bad HTML filtering regexp

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -45,19 +45,14 @@ export function calculateTotalDownloadsFromAllReleases(
     .reduce((total, asset) => total + (asset.download_count || 0), 0);
 }
 
+import DOMPurify from 'dompurify';
+
 export function createSafeMarkdown(content: string): string {
   if (!content || typeof content !== 'string') {
     return '';
   }
   
-  return content
-    .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '')
-    .replace(/<iframe\b[^<]*(?:(?!<\/iframe>)<[^<]*)*<\/iframe>/gi, '')
-    .replace(/javascript:/gi, '')
-    .replace(/data:/gi, '')
-    .replace(/vbscript:/gi, '')
-    .replace(/on\w+\s*=/gi, '')
-    .trim();
+  return DOMPurify.sanitize(content);
 }
 
 export function debounce<T extends (...args: any[]) => any>(

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "next": "^14.2.0",
     "react": "^18.3.0",
     "react-dom": "^18.3.0",
-    "react-markdown": "^9.0.0"
+    "react-markdown": "^9.0.0",
+    "dompurify": "^3.2.6"
   },
   "devDependencies": {
     "@types/node": "^20.19.7",


### PR DESCRIPTION
Potential fix for [https://github.com/Elcapitanoe/buildprop-webpage/security/code-scanning/2](https://github.com/Elcapitanoe/buildprop-webpage/security/code-scanning/2)

To fix the issue, we need to replace the faulty regex-based approach with a well-tested HTML sanitization library, such as `DOMPurify`. This ensures proper handling of all edge cases and significantly reduces the risk of XSS vulnerabilities. Libraries like `DOMPurify` are explicitly designed for this purpose and are much more reliable than manually crafting regexes.

The function `createSafeMarkdown` will be updated to use `DOMPurify.sanitize` instead of the current regex-based implementation. This will require installing `DOMPurify` as a dependency and importing it into the file. The updated function will sanitize the input using `DOMPurify` and return the sanitized content.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
