### PR TITLE
Potential fix for code scanning alert no. 5: Incomplete multi-character sanitization

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -50,14 +50,19 @@ export function createSafeMarkdown(content: string): string {
     return '';
   }
   
-  return content
-    .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '')
-    .replace(/<iframe\b[^<]*(?:(?!<\/iframe>)<[^<]*)*<\/iframe>/gi, '')
-    .replace(/javascript:/gi, '')
-    .replace(/data:/gi, '')
-    .replace(/vbscript:/gi, '')
-    .replace(/on\w+\s*=/gi, '')
-    .trim();
+  let previousContent;
+  do {
+    previousContent = content;
+    content = content
+      .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '')
+      .replace(/<iframe\b[^<]*(?:(?!<\/iframe>)<[^<]*)*<\/iframe>/gi, '')
+      .replace(/javascript:/gi, '')
+      .replace(/data:/gi, '')
+      .replace(/vbscript:/gi, '')
+      .replace(/on\w+\s*=/gi, '');
+  } while (content !== previousContent);
+  
+  return content.trim();
 }
 
 export function debounce<T extends (...args: any[]) => any>(


### PR DESCRIPTION
Potential fix for [https://github.com/Elcapitanoe/buildprop-webpage/security/code-scanning/5](https://github.com/Elcapitanoe/buildprop-webpage/security/code-scanning/5)

To address the issue flagged in `createSafeMarkdown`, we will modify the function to repeatedly apply the regular expressions until no further replacements are made. This ensures all instances of unsafe content are removed, even in cases of nested or overlapping patterns. The fix will involve wrapping the sanitization logic in a loop that continues until the content remains unchanged after a pass.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
